### PR TITLE
Separate tests and badge update

### DIFF
--- a/.github/workflows/run_qaqc.yaml
+++ b/.github/workflows/run_qaqc.yaml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  TestAndCoverageBadgeUpdate:
-    name: Test and Coverage Badge Update
+  tests:
+    name: pytest
     runs-on: ubuntu-latest
 
     steps:
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install poetry
         run: |
@@ -29,6 +29,19 @@ jobs:
         run: |
           poetry install --no-root --with dev
           poetry run pytest
+  badge:
+    # only run on pushes to main
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+    name: update coverage badge
+    runs-on: ubuntu-latest
+
+    # requires the pytest job above
+    needs: tests
+
+    steps:
+      - name: Build badge
+        run: |
           poetry run coverage-badge -f -o docs/assets/badges/coverage.svg
           echo '<!-- timestamp: '"$(date '+%Y-%m-%d %H:%M:%S')"' -->' >> docs/assets/badges/coverage.svg
 


### PR DESCRIPTION
Currently, any time I push a commit to a branch that has an open PR, CI will add another commit, updating the test coverage badge. Most of the time, this is a trivial commit, since the coverage hasn't actually changed, and it's only the timestamp that gets altered.

This caused friction for me because it meant that, at random intervals after I had `git push`ed to my PR branch, I would need to `git pull --rebase`, to update the coverage badge based on what had happened in CI.

My proposal here is to only run pytest on every push to a PR-linked branch, but update the coverage branch only when merging into main.

I'm not 100% sure this will work as expected. It might also not be the best approach. For example, one might just drop the timestamp, or maybe run some more complex logic to see if the test coverage actually changed (i.e., run `poetry run coverage-badge`, writing the bad to some temporary location, and then proceeding to commit it only if the checked-in file and the temporary file differ?).