### PR TITLE
Patch badge

### DIFF
--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -1,0 +1,22 @@
+name: setup-poetry
+description: Set up poetry environment
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: poetry
+
+    - name: Install poetry
+      run: pip install poetry>=2.0
+      shell: bash
+
+    - name: Install dependencies
+      run: poetry install --no-root --with dev
+      shell: bash

--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -11,7 +11,6 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-        cache: poetry
 
     - name: Install poetry
       run: pip install poetry>=2.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: set up poetry
         uses: ./.github/actions/setup-poetry
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,18 @@
+name: pytest
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: set up poetry
+        uses: ./.github/actions/setup-poetry
+
+      - name: Test
+        run: poetry run pytest

--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -2,8 +2,7 @@ name: Tagging
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   tag:
@@ -16,10 +15,10 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
-        run: pip install toml  # Install toml package to read pyproject.toml
+        run: pip install toml # Install toml package to read pyproject.toml
 
       - name: Get version from pyproject.toml
         id: get_version

--- a/.github/workflows/test_coverage_badge.yaml
+++ b/.github/workflows/test_coverage_badge.yaml
@@ -10,25 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: poetry
-
-      - name: Install poetry
-        run: |
-          pip install poetry>=2.0
+      - name: set up poetry
+        uses: ./.github/actions/setup-poetry
 
       - name: Build badge
         run: |
-          poetry install --no-root --with dev
-          poetry run pytest
           poetry run coverage-badge -f -o docs/assets/badges/coverage.svg
           echo '<!-- timestamp: '"$(date '+%Y-%m-%d %H:%M:%S')"' -->' >> docs/assets/badges/coverage.svg
 

--- a/.github/workflows/test_coverage_badge.yaml
+++ b/.github/workflows/test_coverage_badge.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: set up poetry
         uses: ./.github/actions/setup-poetry
 

--- a/.github/workflows/test_coverage_badge.yaml
+++ b/.github/workflows/test_coverage_badge.yaml
@@ -1,13 +1,12 @@
-name: qaqc
+name: test_coverage_badge
 
 on:
-  pull_request:
   push:
     branches: [main]
 
 jobs:
-  tests:
-    name: pytest
+  test_coverage_badge:
+    name: test coverage badge
     runs-on: ubuntu-latest
 
     steps:
@@ -20,28 +19,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: poetry
 
       - name: Install poetry
         run: |
           pip install poetry>=2.0
 
-      - name: Test
+      - name: Build badge
         run: |
           poetry install --no-root --with dev
           poetry run pytest
-  badge:
-    # only run on pushes to main
-    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-
-    name: update coverage badge
-    runs-on: ubuntu-latest
-
-    # requires the pytest job above
-    needs: tests
-
-    steps:
-      - name: Build badge
-        run: |
           poetry run coverage-badge -f -o docs/assets/badges/coverage.svg
           echo '<!-- timestamp: '"$(date '+%Y-%m-%d %H:%M:%S')"' -->' >> docs/assets/badges/coverage.svg
 


### PR DESCRIPTION
## To do

Solution 1: The badge only gets added when it's updated.

Solution 2: The badge gets committed once per pull to main. But then it has to happen *after* everything else, and not trigger versioning?

## Done

- Create a common setup-poetry action
- Separate the pytest and badge coverage actions, since they don't depend on each other now