### PR TITLE
Cdc-ap66_fix_push_HEAD

### DIFF
--- a/.github/workflows/run_qaqc.yaml
+++ b/.github/workflows/run_qaqc.yaml
@@ -2,6 +2,7 @@ name: qaqc
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, closed]
   push:
     branches: [main]
 
@@ -31,12 +32,12 @@ jobs:
           poetry run pytest
 
       - name: Build badge
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ github.event_name == 'pull_request' && github.envent.pull_request.type == 'closed' }}
         run: |
           poetry run coverage-badge -f -o docs/assets/badges/coverage.svg
           echo '<!-- timestamp: '"$(date '+%Y-%m-%d %H:%M:%S')"' -->' >> docs/assets/badges/coverage.svg
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add docs/assets/badges/coverage.svg
-          git commit -m "Update coverage badge"
+          git commit -m "Updated coverage badge"
           git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/run_qaqc.yaml
+++ b/.github/workflows/run_qaqc.yaml
@@ -40,4 +40,4 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add docs/assets/badges/coverage.svg
           git commit -m "Updated coverage badge"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ The versioning pattern is `YYYY.MM.DD.micro(a/b/{none if release})
 
 ### Fixes
 
-- Iteration on last update since main is the default branch only neads to push to HEAD (not HEAD:<branch>)
+- Iteration on last update since main is the default branch only needs to push to HEAD (not HEAD:<branch>)
 - Changing condition to on pull_request closure instead of push to main
 
 ## [2025.08.14.1a]

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ The versioning pattern is `YYYY.MM.DD.micro(a/b/{none if release})
 ### Fixes
 
 - Iteration on last update since main is the default branch only neads to push to HEAD (not HEAD:<branch>)
+- Changing condition to on pull_request closure instead of push to main
 
 ## [2025.08.14.1a]
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,12 @@ The versioning pattern is `YYYY.MM.DD.micro(a/b/{none if release})
 
 ---
 
+## [2025.08.14.2a]
+
+### Fixes
+
+- Iteration on last update since main is the default branch only neads to push to HEAD (not HEAD:<branch>)
+
 ## [2025.08.14.1a]
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfa.dataops"
-version = "2025.08.14.1a"
+version = "2025.08.14.2a"
 description = "Data cataloging, ETL, modeling, verification, and validation for CFA"
 authors = [
     { name = "Phil Rogers", email = "ap66@cdc.gov" },


### PR DESCRIPTION
## [2025.08.14.2a]

### Fixes

- Iteration on last update since main is the default branch only needs to push to HEAD (not HEAD:<branch>)
- Changing condition to on pull_request closure instead of push to main