### PR TITLE
Generate precise catalog type stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This project provides data tools and low friction access to versioned datasets w
    df = datacat.{{dataset}}.load.get_dataframe()
    df.glimpse()
    ```
+6. Generate project-local type stubs for the installed catalog:
+   ```bash
+   dataops_catalog_stubs
+   ```
+   This writes stubs under `typings/`, which Pyright/Pylance uses by default.
+   For mypy, include that directory with `MYPYPATH=typings`.
 
 Read the [Dataset User Guide](docs/data_user_guide.md) for more information about accessing datasets.
 

--- a/cfa/dataops/catalog.py
+++ b/cfa/dataops/catalog.py
@@ -9,7 +9,7 @@ from importlib import import_module
 from io import BytesIO
 from pathlib import PurePosixPath
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import Any, Literal, overload
 
 import pandas as pd
 import polars as pl
@@ -85,37 +85,13 @@ report_namespaces = get_dataset_dot_path(all_reports_ns_map)
 
 
 class CatalogNamespace(SimpleNamespace):
-    """Recursive namespace wrapper for statically-typed catalog access.
-
-    Runtime instances still behave like ``SimpleNamespace`` objects, but the
-    declared attributes let editors resolve endpoint methods on dynamic access
-    chains such as ``datacat.public.team.dataset.load``.
-    """
-
-    if TYPE_CHECKING:
-        load: "BlobEndpoint"
-        extract: "BlobEndpoint"
-        data: "BlobEndpoint"
-        _ledger_endpoint: "BlobEndpoint"
-        config: dict[str, Any]
-        __namespace_list__: list[str]
-
-    def __getattr__(self, name: str) -> "CatalogNamespace":
-        raise AttributeError(
-            f"{type(self).__name__!s} object has no attribute {name!r}"
-        )
+    """Runtime namespace wrapper for catalog access."""
 
 
 class DatasetEndpoint:
     """The DatasetEndpoint class for including in the datacat namespace.
     This ends the namespace branching at a config file and creates all the
     blob endpoints for each 'stage' of the config (e.g., extract, load, stage_01)."""
-
-    if TYPE_CHECKING:
-        config: dict[str, Any]
-        load: "BlobEndpoint"
-        extract: "BlobEndpoint"
-        data: "BlobEndpoint"
 
     def __init__(self, config_path: str, defaults: dict, ns: str):
         """Basic functionality to interact with datasets to be included

--- a/cfa/dataops/stub_templates/__init__.py
+++ b/cfa/dataops/stub_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Package resources for generated type stubs."""

--- a/cfa/dataops/stub_templates/catalog.pyi.mako
+++ b/cfa/dataops/stub_templates/catalog.pyi.mako
@@ -1,0 +1,123 @@
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any, Literal, overload
+
+import pandas as pd
+import polars as pl
+
+from .reporting.catalog import NotebookEndpoint
+
+
+def get_all_catalogs() -> list[tuple[str, str, str]]: ...
+
+
+class CatalogNamespace(SimpleNamespace):
+    pass
+
+
+class DatasetEndpoint:
+    config_path: str
+    defaults: dict[str, Any]
+    config: dict[str, Any]
+    __ns_str__: str
+    _ledger_location: dict[str, Any]
+
+
+class BlobEndpoint:
+    account: str
+    container: str
+    prefix: str
+    ledger_location: dict[str, Any]
+    is_ledger: bool
+    __ns_str__: str
+    def write_blob(
+        self,
+        file_buffer: bytes | Sequence[bytes],
+        path_after_prefix: str,
+        auto_version: bool = False,
+        append: bool = False,
+    ) -> None: ...
+    def read_blobs(
+        self,
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+        print_version: bool = True,
+    ) -> list[bytes]: ...
+    def read_csv(self, suffix: str) -> pd.DataFrame: ...
+    def get_versions(self) -> list[str]: ...
+    def get_file_ext(
+        self,
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+    ) -> str: ...
+    def download_version_to_local(
+        self,
+        local_path: str,
+        version_spec: str | None = None,
+        force: bool = False,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+    ) -> bool: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["pandas", "pd"] = "pandas",
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pd.DataFrame: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["polars", "pl"],
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pl.DataFrame: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["pl_lazy", "lazy"],
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pl.LazyFrame: ...
+    def ledger_entry(self, action: str) -> None: ...
+    def save_dataframe(
+        self,
+        df: pd.DataFrame | pl.DataFrame,
+        path_after_prefix: str,
+        file_format: str = "parquet",
+        auto_version: bool = False,
+    ) -> None: ...
+    def save_file_to_blob(
+        self,
+        file_path: str,
+        path_after_prefix: str,
+        auto_version: bool = False,
+    ) -> None: ...
+    def save_dir_to_blob(
+        self,
+        dir_path: str,
+        path_after_prefix: str,
+        auto_version: bool = False,
+    ) -> None: ...
+
+
+def dict_to_sn(
+    d: Any,
+    defaults: dict[str, Any] | None = None,
+    ns: str = "",
+) -> CatalogNamespace: ...
+
+
+% for cls in model.classes:
+class ${cls.name}(${cls.base}):
+% if cls.attributes:
+% for attr in cls.attributes:
+    ${attr.name}: ${attr.type_name}
+% endfor
+% else:
+    pass
+% endif
+
+
+% endfor
+datacat: DataCatalog
+reportcat: ReportCatalog

--- a/cfa/dataops/stub_templates/init.pyi.mako
+++ b/cfa/dataops/stub_templates/init.pyi.mako
@@ -1,0 +1,4 @@
+from .catalog import datacat as datacat, reportcat as reportcat
+
+__version__: str
+__all__: list[str]

--- a/cfa/dataops/type_stubs.py
+++ b/cfa/dataops/type_stubs.py
@@ -1,0 +1,387 @@
+"""Generate static type stubs for the installed dataops catalog."""
+
+import argparse
+import keyword
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import tomli
+
+DATASET_STAGE_PREFIX = "stage"
+DEFAULT_STUB_ROOT = Path("typings")
+
+
+@dataclass
+class _Node:
+    children: dict[str, "_Node"] = field(default_factory=dict)
+    dataset_config_path: str | None = None
+    report_path: str | None = None
+
+
+def _ensure_identifier(name: str, namespace: tuple[str, ...]) -> str:
+    if not name.isidentifier() or keyword.iskeyword(name):
+        dotted = ".".join((*namespace, name))
+        raise ValueError(
+            f"Catalog path segment {dotted!r} is not a valid Python identifier."
+        )
+    return name
+
+
+def _class_fragment(name: str) -> str:
+    return "".join(part.capitalize() for part in name.split("_") if part)
+
+
+def _class_name(prefix: str, path: tuple[str, ...], suffix: str) -> str:
+    fragments = "".join(_class_fragment(part) for part in path)
+    return f"_{prefix}{fragments}{suffix}"
+
+
+def _insert_node(
+    root: _Node,
+    path: tuple[str, ...],
+    *,
+    dataset_config_path: str | None = None,
+    report_path: str | None = None,
+) -> None:
+    node = root
+    for segment in path:
+        node = node.children.setdefault(segment, _Node())
+    node.dataset_config_path = dataset_config_path
+    node.report_path = report_path
+
+
+def _walk_dataset_map(
+    mapping: Mapping[str, Any],
+    namespace: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
+    datasets: list[tuple[tuple[str, ...], str]] = []
+    for key, value in mapping.items():
+        segment = _ensure_identifier(str(key), namespace)
+        path = (*namespace, segment)
+        if isinstance(value, str) and value.endswith(".toml"):
+            datasets.append((path, value))
+        elif isinstance(value, Mapping):
+            datasets.extend(_walk_dataset_map(value, path))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, Mapping):
+                    datasets.extend(_walk_dataset_map(item, path))
+    return datasets
+
+
+def _walk_report_map(
+    mapping: Mapping[str, Any],
+    namespace: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
+    reports: list[tuple[tuple[str, ...], str]] = []
+    for key, value in mapping.items():
+        segment = _ensure_identifier(str(key), namespace)
+        path = (*namespace, segment)
+        if isinstance(value, str) and value.endswith(".ipynb"):
+            reports.append((path, value))
+        elif isinstance(value, Mapping):
+            reports.extend(_walk_report_map(value, path))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, Mapping):
+                    reports.extend(_walk_report_map(item, path))
+    return reports
+
+
+def _dataset_stage_names(config_path: str) -> list[str]:
+    with open(config_path, "rb") as f:
+        config = tomli.load(f)
+    return [
+        key
+        for key in config
+        if key in {"load", "extract", "data"} or key.startswith(DATASET_STAGE_PREFIX)
+    ]
+
+
+def _indent(lines: list[str], level: int = 1) -> list[str]:
+    prefix = "    " * level
+    return [f"{prefix}{line}" if line else "" for line in lines]
+
+
+def _empty_body(lines: list[str]) -> list[str]:
+    return lines if lines else ["pass"]
+
+
+def _emit_dataset_class(
+    lines: list[str],
+    class_name: str,
+    config_path: str,
+) -> None:
+    stages = _dataset_stage_names(config_path)
+    body = ["config: dict[str, Any]"]
+    body.extend(f"{stage}: BlobEndpoint" for stage in stages)
+    lines.append(f"class {class_name}(DatasetEndpoint):")
+    lines.extend(_indent(_empty_body(body)))
+    lines.append("")
+
+
+def _emit_report_class(lines: list[str], class_name: str) -> None:
+    lines.append(f"class {class_name}(NotebookEndpoint):")
+    lines.extend(_indent(["pass"]))
+    lines.append("")
+
+
+def _emit_namespace_class(
+    lines: list[str],
+    node: _Node,
+    *,
+    prefix: str,
+    path: tuple[str, ...],
+    root_name: str,
+    is_dataset_catalog: bool,
+) -> str:
+    child_attrs: list[tuple[str, str]] = []
+    for name, child in sorted(node.children.items()):
+        child_path = (*path, name)
+        if child.dataset_config_path is not None:
+            child_class = _class_name(prefix, child_path, "Dataset")
+            _emit_dataset_class(lines, child_class, child.dataset_config_path)
+        elif child.report_path is not None:
+            child_class = _class_name(prefix, child_path, "Report")
+            _emit_report_class(lines, child_class)
+        else:
+            child_class = _emit_namespace_class(
+                lines,
+                child,
+                prefix=prefix,
+                path=child_path,
+                root_name=root_name,
+                is_dataset_catalog=is_dataset_catalog,
+            )
+        child_attrs.append((name, child_class))
+
+    class_name = root_name if not path else _class_name(prefix, path, "Namespace")
+    body = [f"{name}: {child_class}" for name, child_class in child_attrs]
+    if not path:
+        body.append("__namespace_list__: list[str]")
+    elif is_dataset_catalog and len(path) == 1:
+        body.append("_ledger_endpoint: BlobEndpoint")
+
+    lines.append(f"class {class_name}(CatalogNamespace):")
+    lines.extend(_indent(_empty_body(body)))
+    lines.append("")
+    return class_name
+
+
+def _build_dataset_tree(dataset_ns_map: Mapping[str, Any]) -> _Node:
+    root = _Node()
+    for path, config_path in _walk_dataset_map(dataset_ns_map):
+        _insert_node(root, path, dataset_config_path=config_path)
+    return root
+
+
+def _build_report_tree(report_ns_map: Mapping[str, Any]) -> _Node:
+    root = _Node()
+    for path, report_path in _walk_report_map(report_ns_map):
+        _insert_node(root, path, report_path=report_path)
+    return root
+
+
+def render_catalog_stub(
+    dataset_ns_map: Mapping[str, Any],
+    report_ns_map: Mapping[str, Any],
+) -> str:
+    """Render a precise ``cfa.dataops.catalog`` stub for installed catalogs."""
+
+    lines = [
+        "from collections.abc import Sequence",
+        "from types import SimpleNamespace",
+        "from typing import Any, Literal, overload",
+        "",
+        "import pandas as pd",
+        "import polars as pl",
+        "",
+        "from .reporting.catalog import NotebookEndpoint",
+        "",
+        "",
+        "def get_all_catalogs() -> list[tuple[str, str, str]]: ...",
+        "",
+        "",
+        "class CatalogNamespace(SimpleNamespace):",
+        "    pass",
+        "",
+        "",
+        "class DatasetEndpoint:",
+        "    config_path: str",
+        "    defaults: dict[str, Any]",
+        "    config: dict[str, Any]",
+        "    __ns_str__: str",
+        "    _ledger_location: dict[str, Any]",
+        "",
+        "",
+        "class BlobEndpoint:",
+        "    account: str",
+        "    container: str",
+        "    prefix: str",
+        "    ledger_location: dict[str, Any]",
+        "    is_ledger: bool",
+        "    __ns_str__: str",
+        "    def write_blob(",
+        "        self,",
+        "        file_buffer: bytes | Sequence[bytes],",
+        "        path_after_prefix: str,",
+        "        auto_version: bool = False,",
+        "        append: bool = False,",
+        "    ) -> None: ...",
+        "    def read_blobs(",
+        "        self,",
+        "        version_spec: str | None = None,",
+        '        selection: Literal["newest", "oldest", "all"] = "newest",',
+        "        print_version: bool = True,",
+        "    ) -> list[bytes]: ...",
+        "    def read_csv(self, suffix: str) -> pd.DataFrame: ...",
+        "    def get_versions(self) -> list[str]: ...",
+        "    def get_file_ext(",
+        "        self,",
+        "        version_spec: str | None = None,",
+        '        selection: Literal["newest", "oldest", "all"] = "newest",',
+        "    ) -> str: ...",
+        "    def download_version_to_local(",
+        "        self,",
+        "        local_path: str,",
+        "        version_spec: str | None = None,",
+        "        force: bool = False,",
+        '        selection: Literal["newest", "oldest", "all"] = "newest",',
+        "    ) -> bool: ...",
+        "    @overload",
+        "    def get_dataframe(",
+        "        self,",
+        '        output: Literal["pandas", "pd"] = "pandas",',
+        "        version_spec: str | None = None,",
+        '        selection: Literal["newest", "oldest"] = "newest",',
+        "    ) -> pd.DataFrame: ...",
+        "    @overload",
+        "    def get_dataframe(",
+        "        self,",
+        '        output: Literal["polars", "pl"],',
+        "        version_spec: str | None = None,",
+        '        selection: Literal["newest", "oldest"] = "newest",',
+        "    ) -> pl.DataFrame: ...",
+        "    @overload",
+        "    def get_dataframe(",
+        "        self,",
+        '        output: Literal["pl_lazy", "lazy"],',
+        "        version_spec: str | None = None,",
+        '        selection: Literal["newest", "oldest"] = "newest",',
+        "    ) -> pl.LazyFrame: ...",
+        "    def ledger_entry(self, action: str) -> None: ...",
+        "    def save_dataframe(",
+        "        self,",
+        "        df: pd.DataFrame | pl.DataFrame,",
+        "        path_after_prefix: str,",
+        '        file_format: str = "parquet",',
+        "        auto_version: bool = False,",
+        "    ) -> None: ...",
+        "    def save_file_to_blob(",
+        "        self,",
+        "        file_path: str,",
+        "        path_after_prefix: str,",
+        "        auto_version: bool = False,",
+        "    ) -> None: ...",
+        "    def save_dir_to_blob(",
+        "        self,",
+        "        dir_path: str,",
+        "        path_after_prefix: str,",
+        "        auto_version: bool = False,",
+        "    ) -> None: ...",
+        "",
+        "",
+        "def dict_to_sn(",
+        "    d: Any,",
+        "    defaults: dict[str, Any] | None = None,",
+        '    ns: str = "",',
+        ") -> CatalogNamespace: ...",
+        "",
+        "",
+    ]
+
+    _emit_namespace_class(
+        lines,
+        _build_dataset_tree(dataset_ns_map),
+        prefix="DataCatalog",
+        path=(),
+        root_name="DataCatalog",
+        is_dataset_catalog=True,
+    )
+    _emit_namespace_class(
+        lines,
+        _build_report_tree(report_ns_map),
+        prefix="ReportCatalog",
+        path=(),
+        root_name="ReportCatalog",
+        is_dataset_catalog=False,
+    )
+    lines.extend(
+        [
+            "datacat: DataCatalog",
+            "reportcat: ReportCatalog",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_init_stub() -> str:
+    return "\n".join(
+        [
+            "from .catalog import datacat as datacat, reportcat as reportcat",
+            "",
+            "__version__: str",
+            '__all__: list[str]',
+            "",
+        ]
+    )
+
+
+def write_catalog_stubs(
+    output_root: str | Path = DEFAULT_STUB_ROOT,
+    *,
+    dataset_ns_map: Mapping[str, Any],
+    report_ns_map: Mapping[str, Any],
+) -> list[Path]:
+    output_root = Path(output_root)
+    package_root = output_root / "cfa" / "dataops"
+    package_root.mkdir(parents=True, exist_ok=True)
+
+    catalog_stub = package_root / "catalog.pyi"
+    init_stub = package_root / "__init__.pyi"
+    catalog_stub.write_text(
+        render_catalog_stub(dataset_ns_map, report_ns_map),
+        encoding="utf-8",
+    )
+    init_stub.write_text(render_init_stub(), encoding="utf-8")
+    return [catalog_stub, init_stub]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate project-local type stubs for the installed dataops catalog."
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_STUB_ROOT,
+        help="Root directory for generated stubs. Defaults to ./typings.",
+    )
+    args = parser.parse_args()
+
+    from .catalog import all_dataset_ns_map, all_reports_ns_map
+
+    written = write_catalog_stubs(
+        args.output_root,
+        dataset_ns_map=all_dataset_ns_map,
+        report_ns_map=all_reports_ns_map,
+    )
+    for path in written:
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/cfa/dataops/type_stubs.py
+++ b/cfa/dataops/type_stubs.py
@@ -222,8 +222,8 @@ def _build_stub_model(
 
 
 def _render_template(template_name: str, **context: Any) -> str:
-    template = files(TEMPLATE_PACKAGE).joinpath(template_name).read_text(
-        encoding="utf-8"
+    template = (
+        files(TEMPLATE_PACKAGE).joinpath(template_name).read_text(encoding="utf-8")
     )
     return Template(template).render(**context)
 

--- a/cfa/dataops/type_stubs.py
+++ b/cfa/dataops/type_stubs.py
@@ -4,13 +4,16 @@ import argparse
 import keyword
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
 import tomli
+from mako.template import Template
 
 DATASET_STAGE_PREFIX = "stage"
 DEFAULT_STUB_ROOT = Path("typings")
+TEMPLATE_PACKAGE = "cfa.dataops.stub_templates"
 
 
 @dataclass
@@ -18,6 +21,24 @@ class _Node:
     children: dict[str, "_Node"] = field(default_factory=dict)
     dataset_config_path: str | None = None
     report_path: str | None = None
+
+
+@dataclass(frozen=True)
+class _StubAttribute:
+    name: str
+    type_name: str
+
+
+@dataclass(frozen=True)
+class _StubClass:
+    name: str
+    base: str
+    attributes: tuple[_StubAttribute, ...] = ()
+
+
+@dataclass(frozen=True)
+class _StubModel:
+    classes: tuple[_StubClass, ...]
 
 
 def _ensure_identifier(name: str, namespace: tuple[str, ...]) -> str:
@@ -100,74 +121,69 @@ def _dataset_stage_names(config_path: str) -> list[str]:
     ]
 
 
-def _indent(lines: list[str], level: int = 1) -> list[str]:
-    prefix = "    " * level
-    return [f"{prefix}{line}" if line else "" for line in lines]
+def _dataset_class(class_name: str, config_path: str) -> _StubClass:
+    attributes = [_StubAttribute("config", "dict[str, Any]")]
+    attributes.extend(
+        _StubAttribute(stage, "BlobEndpoint")
+        for stage in _dataset_stage_names(config_path)
+    )
+    return _StubClass(
+        name=class_name,
+        base="DatasetEndpoint",
+        attributes=tuple(attributes),
+    )
 
 
-def _empty_body(lines: list[str]) -> list[str]:
-    return lines if lines else ["pass"]
+def _report_class(class_name: str) -> _StubClass:
+    return _StubClass(name=class_name, base="NotebookEndpoint")
 
 
-def _emit_dataset_class(
-    lines: list[str],
-    class_name: str,
-    config_path: str,
-) -> None:
-    stages = _dataset_stage_names(config_path)
-    body = ["config: dict[str, Any]"]
-    body.extend(f"{stage}: BlobEndpoint" for stage in stages)
-    lines.append(f"class {class_name}(DatasetEndpoint):")
-    lines.extend(_indent(_empty_body(body)))
-    lines.append("")
-
-
-def _emit_report_class(lines: list[str], class_name: str) -> None:
-    lines.append(f"class {class_name}(NotebookEndpoint):")
-    lines.extend(_indent(["pass"]))
-    lines.append("")
-
-
-def _emit_namespace_class(
-    lines: list[str],
+def _namespace_classes(
     node: _Node,
     *,
     prefix: str,
     path: tuple[str, ...],
     root_name: str,
     is_dataset_catalog: bool,
-) -> str:
+) -> tuple[list[_StubClass], str]:
+    classes: list[_StubClass] = []
     child_attrs: list[tuple[str, str]] = []
     for name, child in sorted(node.children.items()):
         child_path = (*path, name)
         if child.dataset_config_path is not None:
             child_class = _class_name(prefix, child_path, "Dataset")
-            _emit_dataset_class(lines, child_class, child.dataset_config_path)
+            classes.append(_dataset_class(child_class, child.dataset_config_path))
         elif child.report_path is not None:
             child_class = _class_name(prefix, child_path, "Report")
-            _emit_report_class(lines, child_class)
+            classes.append(_report_class(child_class))
         else:
-            child_class = _emit_namespace_class(
-                lines,
+            child_classes, child_class = _namespace_classes(
                 child,
                 prefix=prefix,
                 path=child_path,
                 root_name=root_name,
                 is_dataset_catalog=is_dataset_catalog,
             )
+            classes.extend(child_classes)
         child_attrs.append((name, child_class))
 
     class_name = root_name if not path else _class_name(prefix, path, "Namespace")
-    body = [f"{name}: {child_class}" for name, child_class in child_attrs]
+    attributes = [
+        _StubAttribute(name, child_class) for name, child_class in child_attrs
+    ]
     if not path:
-        body.append("__namespace_list__: list[str]")
+        attributes.append(_StubAttribute("__namespace_list__", "list[str]"))
     elif is_dataset_catalog and len(path) == 1:
-        body.append("_ledger_endpoint: BlobEndpoint")
+        attributes.append(_StubAttribute("_ledger_endpoint", "BlobEndpoint"))
 
-    lines.append(f"class {class_name}(CatalogNamespace):")
-    lines.extend(_indent(_empty_body(body)))
-    lines.append("")
-    return class_name
+    classes.append(
+        _StubClass(
+            name=class_name,
+            base="CatalogNamespace",
+            attributes=tuple(attributes),
+        )
+    )
+    return classes, class_name
 
 
 def _build_dataset_tree(dataset_ns_map: Mapping[str, Any]) -> _Node:
@@ -184,160 +200,48 @@ def _build_report_tree(report_ns_map: Mapping[str, Any]) -> _Node:
     return root
 
 
-def render_catalog_stub(
+def _build_stub_model(
     dataset_ns_map: Mapping[str, Any],
     report_ns_map: Mapping[str, Any],
-) -> str:
-    """Render a precise ``cfa.dataops.catalog`` stub for installed catalogs."""
-
-    lines = [
-        "from collections.abc import Sequence",
-        "from types import SimpleNamespace",
-        "from typing import Any, Literal, overload",
-        "",
-        "import pandas as pd",
-        "import polars as pl",
-        "",
-        "from .reporting.catalog import NotebookEndpoint",
-        "",
-        "",
-        "def get_all_catalogs() -> list[tuple[str, str, str]]: ...",
-        "",
-        "",
-        "class CatalogNamespace(SimpleNamespace):",
-        "    pass",
-        "",
-        "",
-        "class DatasetEndpoint:",
-        "    config_path: str",
-        "    defaults: dict[str, Any]",
-        "    config: dict[str, Any]",
-        "    __ns_str__: str",
-        "    _ledger_location: dict[str, Any]",
-        "",
-        "",
-        "class BlobEndpoint:",
-        "    account: str",
-        "    container: str",
-        "    prefix: str",
-        "    ledger_location: dict[str, Any]",
-        "    is_ledger: bool",
-        "    __ns_str__: str",
-        "    def write_blob(",
-        "        self,",
-        "        file_buffer: bytes | Sequence[bytes],",
-        "        path_after_prefix: str,",
-        "        auto_version: bool = False,",
-        "        append: bool = False,",
-        "    ) -> None: ...",
-        "    def read_blobs(",
-        "        self,",
-        "        version_spec: str | None = None,",
-        '        selection: Literal["newest", "oldest", "all"] = "newest",',
-        "        print_version: bool = True,",
-        "    ) -> list[bytes]: ...",
-        "    def read_csv(self, suffix: str) -> pd.DataFrame: ...",
-        "    def get_versions(self) -> list[str]: ...",
-        "    def get_file_ext(",
-        "        self,",
-        "        version_spec: str | None = None,",
-        '        selection: Literal["newest", "oldest", "all"] = "newest",',
-        "    ) -> str: ...",
-        "    def download_version_to_local(",
-        "        self,",
-        "        local_path: str,",
-        "        version_spec: str | None = None,",
-        "        force: bool = False,",
-        '        selection: Literal["newest", "oldest", "all"] = "newest",',
-        "    ) -> bool: ...",
-        "    @overload",
-        "    def get_dataframe(",
-        "        self,",
-        '        output: Literal["pandas", "pd"] = "pandas",',
-        "        version_spec: str | None = None,",
-        '        selection: Literal["newest", "oldest"] = "newest",',
-        "    ) -> pd.DataFrame: ...",
-        "    @overload",
-        "    def get_dataframe(",
-        "        self,",
-        '        output: Literal["polars", "pl"],',
-        "        version_spec: str | None = None,",
-        '        selection: Literal["newest", "oldest"] = "newest",',
-        "    ) -> pl.DataFrame: ...",
-        "    @overload",
-        "    def get_dataframe(",
-        "        self,",
-        '        output: Literal["pl_lazy", "lazy"],',
-        "        version_spec: str | None = None,",
-        '        selection: Literal["newest", "oldest"] = "newest",',
-        "    ) -> pl.LazyFrame: ...",
-        "    def ledger_entry(self, action: str) -> None: ...",
-        "    def save_dataframe(",
-        "        self,",
-        "        df: pd.DataFrame | pl.DataFrame,",
-        "        path_after_prefix: str,",
-        '        file_format: str = "parquet",',
-        "        auto_version: bool = False,",
-        "    ) -> None: ...",
-        "    def save_file_to_blob(",
-        "        self,",
-        "        file_path: str,",
-        "        path_after_prefix: str,",
-        "        auto_version: bool = False,",
-        "    ) -> None: ...",
-        "    def save_dir_to_blob(",
-        "        self,",
-        "        dir_path: str,",
-        "        path_after_prefix: str,",
-        "        auto_version: bool = False,",
-        "    ) -> None: ...",
-        "",
-        "",
-        "def dict_to_sn(",
-        "    d: Any,",
-        "    defaults: dict[str, Any] | None = None,",
-        '    ns: str = "",',
-        ") -> CatalogNamespace: ...",
-        "",
-        "",
-    ]
-
-    _emit_namespace_class(
-        lines,
+) -> _StubModel:
+    dataset_classes, _ = _namespace_classes(
         _build_dataset_tree(dataset_ns_map),
         prefix="DataCatalog",
         path=(),
         root_name="DataCatalog",
         is_dataset_catalog=True,
     )
-    _emit_namespace_class(
-        lines,
+    report_classes, _ = _namespace_classes(
         _build_report_tree(report_ns_map),
         prefix="ReportCatalog",
         path=(),
         root_name="ReportCatalog",
         is_dataset_catalog=False,
     )
-    lines.extend(
-        [
-            "datacat: DataCatalog",
-            "reportcat: ReportCatalog",
-            "",
-        ]
+    return _StubModel(classes=tuple([*dataset_classes, *report_classes]))
+
+
+def _render_template(template_name: str, **context: Any) -> str:
+    template = files(TEMPLATE_PACKAGE).joinpath(template_name).read_text(
+        encoding="utf-8"
     )
-    return "\n".join(lines)
+    return Template(template).render(**context)
+
+
+def render_catalog_stub(
+    dataset_ns_map: Mapping[str, Any],
+    report_ns_map: Mapping[str, Any],
+) -> str:
+    """Render a precise ``cfa.dataops.catalog`` stub for installed catalogs."""
+
+    return _render_template(
+        "catalog.pyi.mako",
+        model=_build_stub_model(dataset_ns_map, report_ns_map),
+    )
 
 
 def render_init_stub() -> str:
-    return "\n".join(
-        [
-            "from .catalog import datacat as datacat, reportcat as reportcat",
-            "",
-            "__version__: str",
-            '__all__: list[str]',
-            "",
-        ]
-    )
+    return _render_template("init.pyi.mako")
 
 
 def write_catalog_stubs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dataops_datasets = "cfa.dataops.command:get_available_data"
 dataops_stages = "cfa.dataops.command:get_dataset_stages"
 dataops_versions = "cfa.dataops.command:get_dataset_versions"
 dataops_save = "cfa.dataops.command:save_data_locally"
+dataops_catalog_stubs = "cfa.dataops.type_stubs:main"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,15 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    { path = "cfa/dataops/py.typed" },
+    "cfa/dataops/py.typed",
+    "cfa/dataops/stub_templates/*.mako",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["cfa"]
 include = [
-    { path = "cfa/dataops/py.typed" },
+    "cfa/dataops/py.typed",
+    "cfa/dataops/stub_templates/*.mako",
 ]
 
 [tool.hatch.metadata]

--- a/tests/fixtures/expected_catalog_stub.pyi
+++ b/tests/fixtures/expected_catalog_stub.pyi
@@ -1,0 +1,149 @@
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any, Literal, overload
+
+import pandas as pd
+import polars as pl
+
+from .reporting.catalog import NotebookEndpoint
+
+
+def get_all_catalogs() -> list[tuple[str, str, str]]: ...
+
+
+class CatalogNamespace(SimpleNamespace):
+    pass
+
+
+class DatasetEndpoint:
+    config_path: str
+    defaults: dict[str, Any]
+    config: dict[str, Any]
+    __ns_str__: str
+    _ledger_location: dict[str, Any]
+
+
+class BlobEndpoint:
+    account: str
+    container: str
+    prefix: str
+    ledger_location: dict[str, Any]
+    is_ledger: bool
+    __ns_str__: str
+    def write_blob(
+        self,
+        file_buffer: bytes | Sequence[bytes],
+        path_after_prefix: str,
+        auto_version: bool = False,
+        append: bool = False,
+    ) -> None: ...
+    def read_blobs(
+        self,
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+        print_version: bool = True,
+    ) -> list[bytes]: ...
+    def read_csv(self, suffix: str) -> pd.DataFrame: ...
+    def get_versions(self) -> list[str]: ...
+    def get_file_ext(
+        self,
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+    ) -> str: ...
+    def download_version_to_local(
+        self,
+        local_path: str,
+        version_spec: str | None = None,
+        force: bool = False,
+        selection: Literal["newest", "oldest", "all"] = "newest",
+    ) -> bool: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["pandas", "pd"] = "pandas",
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pd.DataFrame: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["polars", "pl"],
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pl.DataFrame: ...
+    @overload
+    def get_dataframe(
+        self,
+        output: Literal["pl_lazy", "lazy"],
+        version_spec: str | None = None,
+        selection: Literal["newest", "oldest"] = "newest",
+    ) -> pl.LazyFrame: ...
+    def ledger_entry(self, action: str) -> None: ...
+    def save_dataframe(
+        self,
+        df: pd.DataFrame | pl.DataFrame,
+        path_after_prefix: str,
+        file_format: str = "parquet",
+        auto_version: bool = False,
+    ) -> None: ...
+    def save_file_to_blob(
+        self,
+        file_path: str,
+        path_after_prefix: str,
+        auto_version: bool = False,
+    ) -> None: ...
+    def save_dir_to_blob(
+        self,
+        dir_path: str,
+        path_after_prefix: str,
+        auto_version: bool = False,
+    ) -> None: ...
+
+
+def dict_to_sn(
+    d: Any,
+    defaults: dict[str, Any] | None = None,
+    ns: str = "",
+) -> CatalogNamespace: ...
+
+
+class _DataCatalogPublicStfNhsnHrdPrelimDataset(DatasetEndpoint):
+    config: dict[str, Any]
+    extract: BlobEndpoint
+    stage_01: BlobEndpoint
+    load: BlobEndpoint
+
+
+class _DataCatalogPublicStfNamespace(CatalogNamespace):
+    nhsn_hrd_prelim: _DataCatalogPublicStfNhsnHrdPrelimDataset
+
+
+class _DataCatalogPublicNamespace(CatalogNamespace):
+    stf: _DataCatalogPublicStfNamespace
+    _ledger_endpoint: BlobEndpoint
+
+
+class DataCatalog(CatalogNamespace):
+    public: _DataCatalogPublicNamespace
+    __namespace_list__: list[str]
+
+
+class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):
+    pass
+
+
+class _ReportCatalogPublicExamplesNamespace(CatalogNamespace):
+    basic_report: _ReportCatalogPublicExamplesBasicReportReport
+
+
+class _ReportCatalogPublicNamespace(CatalogNamespace):
+    examples: _ReportCatalogPublicExamplesNamespace
+
+
+class ReportCatalog(CatalogNamespace):
+    public: _ReportCatalogPublicNamespace
+    __namespace_list__: list[str]
+
+
+datacat: DataCatalog
+reportcat: ReportCatalog

--- a/tests/test_type_stubs.py
+++ b/tests/test_type_stubs.py
@@ -62,9 +62,7 @@ def _representative_catalog_stub(dataset_config: Path) -> str:
 def test_render_catalog_stub_matches_expected_fixture(tmp_path):
     dataset_config = _write_dataset_config(tmp_path / "example.toml")
     stub = _representative_catalog_stub(dataset_config)
-    expected = (FIXTURES_DIR / "expected_catalog_stub.pyi").read_text(
-        encoding="utf-8"
-    )
+    expected = (FIXTURES_DIR / "expected_catalog_stub.pyi").read_text(encoding="utf-8")
 
     assert stub.strip() == expected.strip()
 
@@ -115,7 +113,9 @@ def test_render_catalog_stub_uses_real_report_paths():
         },
     )
 
-    assert "class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):" in stub
+    assert (
+        "class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):" in stub
+    )
     assert "basic_report: _ReportCatalogPublicExamplesBasicReportReport" in stub
 
 

--- a/tests/test_type_stubs.py
+++ b/tests/test_type_stubs.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import pytest
+
+from cfa.dataops.type_stubs import render_catalog_stub, write_catalog_stubs
+
+
+def _write_dataset_config(path: Path) -> Path:
+    path.write_text(
+        """
+[properties]
+name = "example"
+type = "etl"
+automate = false
+
+[extract]
+account = "account"
+container = "container"
+prefix = "raw/example"
+
+[stage_01]
+account = "account"
+container = "container"
+prefix = "stage/example"
+
+[load]
+account = "account"
+container = "container"
+prefix = "load/example"
+""".strip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_render_catalog_stub_uses_real_dataset_paths_and_stages(tmp_path):
+    dataset_config = _write_dataset_config(tmp_path / "example.toml")
+
+    stub = render_catalog_stub(
+        dataset_ns_map={
+            "public": {
+                "stf": {
+                    "nhsn_hrd_prelim": str(dataset_config),
+                },
+            },
+        },
+        report_ns_map={},
+    )
+
+    assert "class _DataCatalogPublicStfNhsnHrdPrelimDataset(DatasetEndpoint):" in stub
+    assert "nhsn_hrd_prelim: _DataCatalogPublicStfNhsnHrdPrelimDataset" in stub
+    assert "stage_01: BlobEndpoint" in stub
+    assert 'output: Literal["pl_lazy", "lazy"],' in stub
+    assert ") -> pl.LazyFrame: ..." in stub
+
+    public_namespace = stub.split(
+        "class _DataCatalogPublicNamespace(CatalogNamespace):"
+    )[1].split("class DataCatalog(CatalogNamespace):")[0]
+    assert "stf: _DataCatalogPublicStfNamespace" in public_namespace
+    assert "load: BlobEndpoint" not in public_namespace
+
+
+def test_render_catalog_stub_uses_real_report_paths():
+    stub = render_catalog_stub(
+        dataset_ns_map={},
+        report_ns_map={
+            "public": {
+                "examples": {
+                    "basic_report": "/reports/basic_report.ipynb",
+                },
+            },
+        },
+    )
+
+    assert "class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):" in stub
+    assert "basic_report: _ReportCatalogPublicExamplesBasicReportReport" in stub
+
+
+def test_render_catalog_stub_rejects_non_identifier_segments(tmp_path):
+    dataset_config = _write_dataset_config(tmp_path / "example.toml")
+
+    with pytest.raises(ValueError, match="not a valid Python identifier"):
+        render_catalog_stub(
+            dataset_ns_map={"public-data": {"example": str(dataset_config)}},
+            report_ns_map={},
+        )
+
+
+def test_write_catalog_stubs_creates_project_local_stub_tree(tmp_path):
+    dataset_config = _write_dataset_config(tmp_path / "example.toml")
+    output_root = tmp_path / "typings"
+
+    written = write_catalog_stubs(
+        output_root,
+        dataset_ns_map={"public": {"example": str(dataset_config)}},
+        report_ns_map={},
+    )
+
+    assert written == [
+        output_root / "cfa" / "dataops" / "catalog.pyi",
+        output_root / "cfa" / "dataops" / "__init__.pyi",
+    ]
+    assert written[0].exists()
+    assert written[1].exists()
+    assert "datacat: DataCatalog" in written[0].read_text(encoding="utf-8")
+    assert "from .catalog import datacat as datacat" in written[1].read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_type_stubs.py
+++ b/tests/test_type_stubs.py
@@ -1,8 +1,15 @@
+import ast
 from pathlib import Path
 
 import pytest
 
-from cfa.dataops.type_stubs import render_catalog_stub, write_catalog_stubs
+from cfa.dataops.type_stubs import (
+    render_catalog_stub,
+    render_init_stub,
+    write_catalog_stubs,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 def _write_dataset_config(path: Path) -> Path:
@@ -31,6 +38,42 @@ prefix = "load/example"
         encoding="utf-8",
     )
     return path
+
+
+def _representative_catalog_stub(dataset_config: Path) -> str:
+    return render_catalog_stub(
+        dataset_ns_map={
+            "public": {
+                "stf": {
+                    "nhsn_hrd_prelim": str(dataset_config),
+                },
+            },
+        },
+        report_ns_map={
+            "public": {
+                "examples": {
+                    "basic_report": "/reports/basic_report.ipynb",
+                },
+            },
+        },
+    )
+
+
+def test_render_catalog_stub_matches_expected_fixture(tmp_path):
+    dataset_config = _write_dataset_config(tmp_path / "example.toml")
+    stub = _representative_catalog_stub(dataset_config)
+    expected = (FIXTURES_DIR / "expected_catalog_stub.pyi").read_text(
+        encoding="utf-8"
+    )
+
+    assert stub.strip() == expected.strip()
+
+
+def test_render_catalog_stub_outputs_parseable_python_syntax(tmp_path):
+    dataset_config = _write_dataset_config(tmp_path / "example.toml")
+    stub = _representative_catalog_stub(dataset_config)
+
+    ast.parse(stub)
 
 
 def test_render_catalog_stub_uses_real_dataset_paths_and_stages(tmp_path):
@@ -74,6 +117,10 @@ def test_render_catalog_stub_uses_real_report_paths():
 
     assert "class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):" in stub
     assert "basic_report: _ReportCatalogPublicExamplesBasicReportReport" in stub
+
+
+def test_render_init_stub_outputs_parseable_python_syntax():
+    ast.parse(render_init_stub())
 
 
 def test_render_catalog_stub_rejects_non_identifier_segments(tmp_path):

--- a/typings/cfa/dataops/__init__.pyi
+++ b/typings/cfa/dataops/__init__.pyi
@@ -1,0 +1,4 @@
+from .catalog import datacat as datacat, reportcat as reportcat
+
+__version__: str
+__all__: list[str]

--- a/typings/cfa/dataops/__init__.pyi
+++ b/typings/cfa/dataops/__init__.pyi
@@ -1,4 +1,5 @@
-from .catalog import datacat as datacat, reportcat as reportcat
+from .catalog import datacat as datacat
+from .catalog import reportcat as reportcat
 
 __version__: str
 __all__: list[str]

--- a/typings/cfa/dataops/catalog.pyi
+++ b/typings/cfa/dataops/catalog.pyi
@@ -7,10 +7,13 @@ import polars as pl
 
 from .reporting.catalog import NotebookEndpoint
 
+
 def get_all_catalogs() -> list[tuple[str, str, str]]: ...
+
 
 class CatalogNamespace(SimpleNamespace):
     pass
+
 
 class DatasetEndpoint:
     config_path: str
@@ -18,6 +21,7 @@ class DatasetEndpoint:
     config: dict[str, Any]
     __ns_str__: str
     _ledger_location: dict[str, Any]
+
 
 class BlobEndpoint:
     account: str
@@ -95,40 +99,18 @@ class BlobEndpoint:
         auto_version: bool = False,
     ) -> None: ...
 
+
 def dict_to_sn(
     d: Any,
     defaults: dict[str, Any] | None = None,
     ns: str = "",
 ) -> CatalogNamespace: ...
 
-class _DataCatalogPublicStfNhsnHrdPrelimDataset(DatasetEndpoint):
-    config: dict[str, Any]
-    extract: BlobEndpoint
-    stage_01: BlobEndpoint
-    load: BlobEndpoint
-
-class _DataCatalogPublicStfNamespace(CatalogNamespace):
-    nhsn_hrd_prelim: _DataCatalogPublicStfNhsnHrdPrelimDataset
-
-class _DataCatalogPublicNamespace(CatalogNamespace):
-    stf: _DataCatalogPublicStfNamespace
-    _ledger_endpoint: BlobEndpoint
 
 class DataCatalog(CatalogNamespace):
-    public: _DataCatalogPublicNamespace
     __namespace_list__: list[str]
 
-class _ReportCatalogPublicExamplesBasicReportReport(NotebookEndpoint):
-    pass
-
-class _ReportCatalogPublicExamplesNamespace(CatalogNamespace):
-    basic_report: _ReportCatalogPublicExamplesBasicReportReport
-
-class _ReportCatalogPublicNamespace(CatalogNamespace):
-    examples: _ReportCatalogPublicExamplesNamespace
-
 class ReportCatalog(CatalogNamespace):
-    public: _ReportCatalogPublicNamespace
     __namespace_list__: list[str]
 
 datacat: DataCatalog

--- a/typings/cfa/dataops/catalog.pyi
+++ b/typings/cfa/dataops/catalog.pyi
@@ -5,15 +5,10 @@ from typing import Any, Literal, overload
 import pandas as pd
 import polars as pl
 
-from .reporting.catalog import NotebookEndpoint
-
-
 def get_all_catalogs() -> list[tuple[str, str, str]]: ...
-
 
 class CatalogNamespace(SimpleNamespace):
     pass
-
 
 class DatasetEndpoint:
     config_path: str
@@ -21,7 +16,6 @@ class DatasetEndpoint:
     config: dict[str, Any]
     __ns_str__: str
     _ledger_location: dict[str, Any]
-
 
 class BlobEndpoint:
     account: str
@@ -99,13 +93,11 @@ class BlobEndpoint:
         auto_version: bool = False,
     ) -> None: ...
 
-
 def dict_to_sn(
     d: Any,
     defaults: dict[str, Any] | None = None,
     ns: str = "",
 ) -> CatalogNamespace: ...
-
 
 class DataCatalog(CatalogNamespace):
     __namespace_list__: list[str]

--- a/uv.lock
+++ b/uv.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cfa-dataops"
-version = "2026.6.5.0"
+version = "2026.6.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },
@@ -659,9 +659,11 @@ dependencies = [
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandera", extra = ["pandas"] },
     { name = "papermill" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "rich" },
+    { name = "tomli" },
     { name = "tqdm" },
     { name = "vl-convert-python" },
 ]
@@ -675,12 +677,10 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "polars" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
-    { name = "tomli" },
 ]
 
 [package.metadata]
@@ -702,9 +702,11 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pandera", extras = ["pandas"], specifier = ">=0.24.0" },
     { name = "papermill", specifier = ">=2.6.0" },
+    { name = "polars", specifier = ">=1.26.0" },
     { name = "pyarrow", specifier = ">=19.0.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "rich", specifier = ">=14.1.0" },
+    { name = "tomli", specifier = ">=2.2.1" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "vl-convert-python", specifier = ">=1.7.0" },
 ]
@@ -718,12 +720,10 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.16" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.0" },
-    { name = "polars", specifier = ">=1.26.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.9.9" },
-    { name = "tomli", specifier = ">=2.2.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
100% vibecoded alternative to https://github.com/CDCgov/cfa-dataops/pull/98.

I'm not super comfortable adding this to the repo, but it does work as advertised


<img width="591" height="319" alt="CleanShot 2026-06-25 at 17 43 02@2x" src="https://github.com/user-attachments/assets/ce5057c0-7cf5-4ca7-a849-0f628f6468bf" />


<img width="581" height="201" alt="CleanShot 2026-06-25 at 17 43 10@2x" src="https://github.com/user-attachments/assets/d22ac66e-070b-4b33-8a92-44e5aae72bc7" />
<img width="524" height="134" alt="CleanShot 2026-06-25 at 18 01 27@2x" src="https://github.com/user-attachments/assets/50c00c5e-a2da-4a32-b6be-f326d5e05006" />


:

<details><summary>Codex Explanation</summary>
<p>

## Summary

This PR replaces the broad inline `CatalogNamespace` type-hint workaround with generated `.pyi` stubs for the installed catalog tree.

The original approach improved editor inference for expressions like:

```python
datacat.public.stf.nhsn_hrd_prelim.load.get_dataframe(output="lazy")
```

but it did so by declaring endpoint attributes such as `load`, `extract`, and `data` on every catalog namespace. That made invalid paths look valid to static analyzers.

This PR adds a `dataops_catalog_stubs` command that inspects the installed catalog maps and dataset TOML configs, then writes project-local stubs under:

```text
typings/cfa/dataops/
```

The generated stubs model:

- real `datacat` namespace paths
- real `reportcat` namespace paths
- terminal dataset endpoints as `DatasetEndpoint`
- actual runtime blob stages from TOML, including `load`, `extract`, `data`, and `stage_*`
- `BlobEndpoint.get_dataframe()` overloads, preserving inference such as `output="lazy" -> polars.LazyFrame`

## Why

`cfa-dataops` discovers catalogs dynamically from installed packages such as `CDCgov/cfa-catalog-pub`, so inline annotations in `catalog.py` cannot accurately describe the real installed namespace tree.

Generated stubs are a better fit because they are created from the same installed catalog state used at runtime. For `cfa-catalog-pub`, this means paths like:

```python
datacat.public.stf.nhsn_hrd_prelim.load
```

can be represented precisely, while non-terminal namespaces like:

```python
datacat.public
datacat.public.stf
```

do not falsely appear to have blob endpoint methods.

## Maintainability

The first generated-stub draft built the `.pyi` output with a large hand-assembled string, which was too fragile. This version hardens the implementation by:

- moving stable `.pyi` syntax into Mako templates
- keeping `type_stubs.py` focused on catalog-tree/model construction
- adding a golden-file fixture for representative generated output
- parsing generated stubs with `ast.parse()` in tests
- packaging the templates explicitly in both wheels and sdists

## User Workflow

After installing the relevant catalog packages, run:

```bash
dataops_catalog_stubs
```

Pyright/Pylance can use the generated `typings/` directory directly. For mypy, use:

```bash
MYPYPATH=typings
```

Regenerate the stubs whenever dataset TOMLs, report notebooks, or catalog paths change.

## Validation

- `uv run ruff check cfa/dataops/type_stubs.py tests/test_type_stubs.py cfa/dataops/stub_templates`
- `uv run pytest tests/test_type_stubs.py -q`
  - Repo pytest config expanded this to the full test suite.
  - 126 tests passed.
- `uv run dataops_catalog_stubs --output-root /private/tmp/cfa-dataops-typings-template-smoke`
- `uv build --out-dir /private/tmp/cfa-dataops-build-template-smoke`
- Confirmed the built wheel contains `cfa/dataops/py.typed` and both Mako templates.

</p>
</details> 